### PR TITLE
fix: Coverage

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,5 +12,8 @@ export default defineConfig({
       },
     },
     environment: 'happy-dom',
+    coverage: {
+      include: ['src/**'],
+    },
   },
 });


### PR DESCRIPTION
Only include `src` files in the coverage report