### PR TITLE
test(loaders): add unit tests for cloudinaryLoader

### DIFF
--- a/src/loaders/__tests__/cloudinary.test.ts
+++ b/src/loaders/__tests__/cloudinary.test.ts
@@ -21,6 +21,8 @@ describe('cloudinaryLoader', () => {
   it('reflects the width parameter in the URL', () => {
     const result = cloudinaryLoader({ src: 'photo.jpg', width: 1200 });
 
-    expect(result).toContain('w_1200');
+    expect(result).toBe(
+      'https://res.cloudinary.com/nicolebunge/image/upload/c_limit,f_auto,q_auto,w_1200/v1627923793/photo.jpg',
+    );
   });
 });

--- a/src/loaders/__tests__/cloudinary.test.ts
+++ b/src/loaders/__tests__/cloudinary.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import cloudinaryLoader from '../cloudinary';
+
+describe('cloudinaryLoader', () => {
+  it('uses q_auto when no quality is provided', () => {
+    const result = cloudinaryLoader({ src: 'photo.jpg', width: 800 });
+
+    expect(result).toBe(
+      'https://res.cloudinary.com/nicolebunge/image/upload/c_limit,f_auto,q_auto,w_800/v1627923793/photo.jpg',
+    );
+  });
+
+  it('reflects an explicit quality value in the URL', () => {
+    const result = cloudinaryLoader({ src: 'photo.jpg', width: 800, quality: 80 });
+
+    expect(result).toBe(
+      'https://res.cloudinary.com/nicolebunge/image/upload/c_limit,f_auto,q_80,w_800/v1627923793/photo.jpg',
+    );
+  });
+
+  it('reflects the width parameter in the URL', () => {
+    const result = cloudinaryLoader({ src: 'photo.jpg', width: 1200 });
+
+    expect(result).toContain('w_1200');
+  });
+});


### PR DESCRIPTION
## Summary

Adds a unit test file for the `cloudinaryLoader` function, locking in its URL output for the key cases.

## Test cases

- Default quality → expects `q_auto` in the URL
- Explicit quality (e.g. `80`) → expects `q_80` reflected in the URL
- Width passthrough → expects `w_<n>` reflected correctly

## Related

Closes #1591