### PR TITLE
feat(utils): surface formatList through the string utility interface

### DIFF
--- a/src/components/Production/Production.tsx
+++ b/src/components/Production/Production.tsx
@@ -1,10 +1,5 @@
 import Link from '../Link';
-
-function formatList(list: string[]): string {
-  return list.reduce(
-    (text, value, i, array) => text + (i < array.length - 1 ? ', ' : ' & ') + value,
-  );
-}
+import { formatList } from '../../utils/string';
 
 interface Director {
   id: string;

--- a/src/utils/__tests__/string.test.ts
+++ b/src/utils/__tests__/string.test.ts
@@ -1,5 +1,25 @@
 import { describe, expect, it } from 'vitest';
-import { isExternalUrl } from '../string';
+import { formatList, isExternalUrl } from '../string';
+
+describe('formatList', () => {
+  it('should return the item itself for a single item', () => {
+    expect.assertions(1);
+
+    expect(formatList(['Alice'])).toStrictEqual('Alice');
+  });
+
+  it('should join two items with " & "', () => {
+    expect.assertions(1);
+
+    expect(formatList(['Alice', 'Bob'])).toStrictEqual('Alice & Bob');
+  });
+
+  it('should join three or more items with commas and " & " before the last', () => {
+    expect.assertions(1);
+
+    expect(formatList(['Alice', 'Bob', 'Carol'])).toStrictEqual('Alice, Bob & Carol');
+  });
+});
 
 describe('isExternalUrl', () => {
   it('should check if URL is external', () => {

--- a/src/utils/__tests__/string.test.ts
+++ b/src/utils/__tests__/string.test.ts
@@ -8,13 +8,13 @@ describe('formatList', () => {
     expect(formatList(['Alice'])).toStrictEqual('Alice');
   });
 
-  it('should join two items with " & "', () => {
+  it('should join two items with "&"', () => {
     expect.assertions(1);
 
     expect(formatList(['Alice', 'Bob'])).toStrictEqual('Alice & Bob');
   });
 
-  it('should join three or more items with commas and " & " before the last', () => {
+  it('should join three or more items with commas and "&" before the last', () => {
     expect.assertions(1);
 
     expect(formatList(['Alice', 'Bob', 'Carol'])).toStrictEqual('Alice, Bob & Carol');

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -2,4 +2,10 @@ function isExternalUrl(url: string): boolean {
   return url.startsWith('http');
 }
 
-export { isExternalUrl };
+function formatList(list: string[]): string {
+  return list.reduce(
+    (text, value, i, array) => text + (i < array.length - 1 ? ', ' : ' & ') + value,
+  );
+}
+
+export { formatList, isExternalUrl };


### PR DESCRIPTION
## Summary

Moves the `formatList` pure function from `Production.tsx` into `utils/string.ts` so it can be tested directly and reused by any future caller.

## Changes

- **`utils/string.ts`** — exports `formatList(list: string[]): string`
- **`utils/__tests__/string.test.ts`** — adds three test cases: single item, two items (only ` & `), three+ items (commas + ` & `)
- **`Production.tsx`** — removes local definition and imports from the utility module

## Closes

Closes #1589